### PR TITLE
Remove alpha channel for apple-touch-icon

### DIFF
--- a/favicon-gen.js
+++ b/favicon-gen.js
@@ -50,6 +50,8 @@ const appleBuf = (bgColor, padding) => async (fileName, fileMeta) =>
         left: padding,
         right: padding,
         background: bgColor,
+      }).flatten({ // to remove alpha channel
+        background: bgColor,
       }).toBuffer());
 
 const defaultOpts = {


### PR DESCRIPTION
I'm not entirely sure of the ramifications of this.
I also didn't add any tests because I didn't see any asserts on image alpha channels/transparency. 

The goal of the change is to have `apple-touch-icon` get the given background color, even if the source image has transparent parts.

Let's discuss if you want to :-)